### PR TITLE
Исправить работу hoverButtons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/andchir/api2app-chat-widget/issues/10
+Your prepared branch: issue-10-8dd9eaa2ed2f
+Your prepared working directory: /tmp/gh-issue-solver-1769197615353
+Your forked repository: konard/andchir-api2app-chat-widget
+Original repository (upstream): andchir/api2app-chat-widget
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/api2app-chat-widget/issues/10
-Your prepared branch: issue-10-8dd9eaa2ed2f
-Your prepared working directory: /tmp/gh-issue-solver-1769197615353
-Your forked repository: konard/andchir-api2app-chat-widget
-Original repository (upstream): andchir/api2app-chat-widget
-
-Proceed.

--- a/api2app-chat-widget.js
+++ b/api2app-chat-widget.js
@@ -189,13 +189,22 @@ class Api2AppChatWidget {
 
         this.options.hoverButtons.forEach((hoverBtn, index) => {
             const btnWrapper = document.createElement('div');
-            btnWrapper.style.position = 'relative';
+            btnWrapper.style.position = 'absolute';
             btnWrapper.style.display = 'flex';
             btnWrapper.style.alignItems = 'center';
             btnWrapper.style.opacity = '0';
             btnWrapper.style.transform = 'translateY(0)';
             btnWrapper.style.transition = `opacity 0.3s ease-in-out, transform 0.3s ease-in-out ${index * 0.05}s`;
             btnWrapper.style.pointerEvents = 'auto';
+            btnWrapper.style.left = '0';
+
+            // Position based on widget position (top or bottom)
+            const isTopPosition = this.options.position.includes('top');
+            if (isTopPosition) {
+                btnWrapper.style.top = '0';
+            } else {
+                btnWrapper.style.bottom = '0';
+            }
 
             const link = document.createElement('a');
             link.href = hoverBtn.href || '#';
@@ -423,9 +432,10 @@ class Api2AppChatWidget {
         this.hoverButtonElements.forEach((btnWrapper, index) => {
             btnWrapper.style.opacity = '1';
             // Calculate distance based on button position
+            // Each button should be positioned at a unique offset from the main button
             const distance = (index + 1) * 70; // 60px button + 10px gap
             if (isTopPosition) {
-                btnWrapper.style.transform = `translateY(-${distance}px)`;
+                btnWrapper.style.transform = `translateY(${distance}px)`;
             } else {
                 btnWrapper.style.transform = `translateY(-${distance}px)`;
             }


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #10

## 🔍 Problem
The hover buttons feature had a critical positioning bug where multiple buttons would overlap each other instead of appearing stacked with proper spacing. When hovering over the main chat button, both the WhatsApp and Telegram buttons would animate to the same position, making only the top button fully visible.

### Root Cause
All button wrappers were using `position: relative` within a flex container, which caused them to:
1. Start at their natural stacked positions in the flex layout
2. Animate with transforms that moved them all to the same offset, causing overlap
3. Both top and bottom widget positions used identical negative transforms

## ✅ Solution
Changed the positioning strategy to use absolute positioning for each button wrapper:

1. **Absolute positioning**: Changed button wrappers from `position: relative` to `position: absolute`
2. **Initial position**: All buttons now start at the same position (`bottom: 0` or `top: 0`)
3. **Unique offsets**: Each button animates to a unique vertical offset based on its index:
   - First button: 70px from main button
   - Second button: 140px from main button
   - And so on...
4. **Fixed top position animation**: Corrected the transform direction for top-positioned widgets to use positive `translateY` values

### Changes Made
- `api2app-chat-widget.js:192`: Changed `position: 'relative'` to `position: 'absolute'`
- `api2app-chat-widget.js:198-206`: Added explicit positioning (`left: 0` and `bottom: 0` or `top: 0`)
- `api2app-chat-widget.js:437`: Fixed top position transform to use positive values

## 🧪 Testing
Verified the fix works correctly by:
- Testing with the experiment page (`experiments/test-hover-buttons.html`)
- Testing with the main demo page (`index.html`)
- Confirming buttons appear stacked with equal spacing (70px between each)
- Verifying tooltips still work correctly
- Testing hover interactions remain smooth

### Before Fix
![Before fix - buttons overlapping](/.playwright-mcp/experiments/before-fix-hover.png)

### After Fix
![After fix - buttons properly stacked](/.playwright-mcp/experiments/after-fix-hover.png)

## 📝 Technical Details
The spacing calculation remains at 70px per button (60px button height + 10px gap), ensuring consistent visual appearance across all widget positions (bottom-right, bottom-left, top-right, top-left).

---
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>