### PR TITLE
[WIP] После нажатия на основную кнопку hoverButtons должны спрятаться обратно

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/api2app-chat-widget/issues/14
-Your prepared branch: issue-14-de27af9e1a53
-Your prepared working directory: /tmp/gh-issue-solver-1769205888548
-Your forked repository: konard/andchir-api2app-chat-widget
-Original repository (upstream): andchir/api2app-chat-widget
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/andchir/api2app-chat-widget/issues/14
+Your prepared branch: issue-14-de27af9e1a53
+Your prepared working directory: /tmp/gh-issue-solver-1769205888548
+Your forked repository: konard/andchir-api2app-chat-widget
+Original repository (upstream): andchir/api2app-chat-widget
+
+Proceed.

--- a/api2app-chat-widget.js
+++ b/api2app-chat-widget.js
@@ -361,6 +361,11 @@ class Api2AppChatWidget {
 
         this.button.onclick = (e) => {
             e.preventDefault();
+            // Hide hover buttons and tooltip with animation when main button is clicked
+            this.hideHoverButtons();
+            if (this.tooltip) {
+                this.hideTooltip();
+            }
             setTimeout(() => {
                 this.toggle();
             }, 100);


### PR DESCRIPTION
## 🎯 Решение

Исправлено поведение виджета при нажатии на основную кнопку. Теперь hover-кнопки и tooltip автоматически скрываются с анимацией.

## 📋 Изменения

### Файл: `api2app-chat-widget.js`
- Добавлен вызов `hideHoverButtons()` при клике на основную кнопку
- Добавлен вызов `hideTooltip()` при клике на основную кнопку (если tooltip существует)
- Оба метода используют существующие анимации для плавного скрытия

## 🔍 Детали реализации

Изменения в обработчике `button.onclick` (строка 362):
```javascript
this.button.onclick = (e) => {
    e.preventDefault();
    // Hide hover buttons and tooltip with animation when main button is clicked
    this.hideHoverButtons();
    if (this.tooltip) {
        this.hideTooltip();
    }
    setTimeout(() => {
        this.toggle();
    }, 100);
};
```

## ✅ Проверено

1. При наведении на кнопку появляются hover-кнопки и tooltip
2. При клике на основную кнопку:
   - Hover-кнопки скрываются с обратной анимацией (opacity: 0, transform: translateY(0))
   - Tooltip скрывается с анимацией (opacity: 0, transform: translateX)
   - Виджет открывается корректно

## 🔗 Связанная задача

Fixes #14

---
*Создано автоматически AI issue solver*